### PR TITLE
Adding tests for findOrCreate

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -223,8 +223,7 @@ describe('Basic tests ::', function() {
 
 										// log.debug('findOne and association result: ');
 										// console.dir(r, {depth: null});
-										console.log(r)
-							
+																
 										expect(r).to.be.an('object');
 										expect(r.statuses).to.be.lengthOf.above(0);
 								});

--- a/test/basic.js
+++ b/test/basic.js
@@ -223,14 +223,42 @@ describe('Basic tests ::', function() {
 
 										// log.debug('findOne and association result: ');
 										// console.dir(r, {depth: null});
-
+										console.log(r)
+							
 										expect(r).to.be.an('object');
 										expect(r.statuses).to.be.lengthOf.above(0);
 								});
 								
 						});
 
-						// findOrCreate cannot populate, so no tests here.
+						// Can't populate findOrCreate but test to ensure nothing breaks 
+
+						context(`findOrCreate #: `, function (){
+							it(`@${__line()} can findOrCreate with Person already existing:`, async function (){
+									
+									let r = await Person.findOrCreate({ id: 2 }, {
+										firstname: 'Test',
+										lastname: 'User'
+									});
+								
+									expect(r).to.be.an('object');
+									expect(r.statuses).to.be.lengthOf.above(0);
+							});
+
+							it(`@${__line()} can findOrCreate with Person created new:`, async function (){
+									
+								let r = await Person.findOrCreate({ id: 999 }, {
+									firstname: 'Test',
+									lastname: 'User'
+								});
+				
+								expect(r).to.be.an('object');
+								expect(r.firstName).to.be.equal('Test')
+								expect(r.lastname).to.be.equal('User')
+						});
+							
+					});
+
 						
 						context(`stream #: `, function (){
 								it(`@${__line()} can stream and populate all  associations on model using populateAll():`, async function (){


### PR DESCRIPTION
Although findOrCreate cannot be populated, I've included to tests to ensure that the findOrCreate functionality remains working.

These tests currently fail due to https://github.com/emahuni/sails-hook-deep-orm/issues/4 